### PR TITLE
v0.4.0: hide `SHARE_MASK` by function `share_mask`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdx-guest"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "The tdx-guest provides a Rust implementation of Intel® Trust Domain Extensions (Intel® TDX) Guest APIs, supporting for TDX Guest specific instructions, structures and functions."
 license = "BSD-3-Clause"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,11 @@ pub enum AcceptError {
 
 pub type TdxGpa = usize;
 
-pub static SHARED_MASK: AtomicU64 = AtomicU64::new(0);
+static SHARED_MASK: AtomicU64 = AtomicU64::new(0);
+
+pub fn shared_mask() -> u64 {
+    SHARED_MASK.load(Relaxed)
+}
 
 pub trait TdxTrapFrame {
     fn rax(&self) -> usize;


### PR DESCRIPTION
See https://github.com/asterinas/asterinas/pull/3588#discussion_r3586006909



<details><summary>This  API change requires a release of major version bump.</summary>
<p>

```bash
confidential-computing.tdx.tdx-guest $ cargo semver-checks
    Building tdx-guest v0.3.2 (current) 👈
       Built [   2.007s] (current)
     Parsing tdx-guest v0.3.2 (current)
      Parsed [   0.005s] (current)
    Building tdx-guest v0.3.2 (baseline)
       Built [   1.825s] (baseline)
     Parsing tdx-guest v0.3.2 (baseline)
      Parsed [   0.005s] (baseline)
    Checking tdx-guest v0.3.2 -> v0.3.2 (no change; assume minor)
     Checked [   0.005s] 196 checks: 195 pass, 1 fail, 0 warn, 57 skip

--- failure pub_static_missing: pub static is missing ---

Description:
A public static is missing, renamed, or made private.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.49.0/src/lints/pub_static_missing.ron

Failed in:
  SHARED_MASK in file /home/zjp/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tdx-guest-0.3.2/src/lib.rs:53

     Summary semver requires new major version: 1 major and 0 minor checks failed 👈
    Finished [   5.177s] tdx-guest
```

```bash
confidential-computing.tdx.tdx-guest $ cargo semver-checks
    Building tdx-guest v0.4.0 (current) 👈
       Built [   1.879s] (current)
     Parsing tdx-guest v0.4.0 (current)
      Parsed [   0.006s] (current)
     Parsing tdx-guest v0.3.2 (baseline, cached)
      Parsed [   0.006s] (baseline)
    Checking tdx-guest v0.3.2 -> v0.4.0 (major change)
     Checked [   0.000s] 0 checks: 0 pass, 253 skip
     Summary no semver update required
    Finished [   2.730s] tdx-guest
```

</p>
</details> 

